### PR TITLE
Allow setting maximum number of fetched pages in search

### DIFF
--- a/oga/core.py
+++ b/oga/core.py
@@ -69,12 +69,13 @@ async def search(session: aiohttp.ClientSession, base_query: str, page_limit: Op
         async with session.get(url) as response:
             return await response.read()
 
-    if page_limit is None or page_limit > 0:
+    assert page_limit is None or page_limit >= 0
+    if page_limit > 0:
         # Special case for first page since we may not continue
         data = await fetch()
         last_page = parse_last_search_page(data)
-        if page_limit is not None and last_page > page_limit:
-            last_page = page_limit - 1
+        if page_limit is not None:
+            last_page = min(last_page, page_limit - 1)
         asset_ids = parse_search_results(data)
         for asset_id in asset_ids:
             yield asset_id

--- a/oga/core.py
+++ b/oga/core.py
@@ -69,8 +69,8 @@ async def search(session: aiohttp.ClientSession, base_query: str, page_limit: Op
         async with session.get(url) as response:
             return await response.read()
 
-    assert page_limit is None or page_limit >= 0
-    if page_limit > 0:
+    assert page_limit is None or page_limit >= 0, "page_limit must be None or non-negative"
+    if page_limit is not None and page_limit > 0:
         # Special case for first page since we may not continue
         data = await fetch()
         last_page = parse_last_search_page(data)

--- a/oga/main/cli.py
+++ b/oga/main/cli.py
@@ -113,11 +113,12 @@ def download_asset(session: Session, asset: str):
 @click.option("--license", type=click.Choice(list(license_type_map.keys())), multiple=True)
 @click.option("--tag", help="freeform tag", multiple=True, type=str)
 @click.option("--tag-op", type=click.Choice(["or", "and", "not", "empty", "not-empty"]), default="or")
+@click.option("--page-limit", help="Maximum number of pages to be fetched", type=int, default=None)
 @click.pass_obj
 def search_assets(
         session: Session, verbose: bool,
         keys: Optional[str], title: Optional[str], submitter: Optional[str],
-        sort_by: str, descending: bool, type: List[str], license: List[str], tag: List[str], tag_op: str):
+        sort_by: str, descending: bool, type: List[str], license: List[str], tag: List[str], tag_op: str, page_limit: Optional[int]):
     """Search for an asset."""
     types = [cli_type_map[x] for x in type]
     licenses = [license_type_map[x] for x in license]
@@ -130,7 +131,8 @@ def search_assets(
         types=types,
         licenses=licenses,
         tags=tag,
-        tag_operation=tag_op
+        tag_operation=tag_op,
+        page_limit=page_limit
     )
 
     async def process():


### PR DESCRIPTION
I've found use in being able to only allowing up to a certain number of pages, expecially when working with a query with a very large number of results but only being interested in a smaller sample.

This modifications allows to specify a maximum number of pages.
The additional parameter is available both for the library and for the GUI and is entirely optional. It can be ignored and is therefore non-breaking.